### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,4 +1,6 @@
 name: Tests
+permissions:
+  contents: read
 
 on: [push, pull_request]
 


### PR DESCRIPTION
Potential fix for [https://github.com/CodeWithSushil/json-db/security/code-scanning/6](https://github.com/CodeWithSushil/json-db/security/code-scanning/6)

To fix this problem, you should add an explicit `permissions` block to the workflow, specifying only the least privilege required. In this case, the job checks out code and runs local tests: it does not need any write access. Thus, the minimal required permissions are `contents: read`. You can add the `permissions` block either to the root of the workflow file (affecting all jobs), or to the specific `phpunit` job. Following GitHub best practices and your provided background, adding it at the root of `.github/workflows/tests.yml` is preferred, just below the `name:` and before the `on:` block. No additional imports or changes are needed—this is a declarative YAML configuration fix.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
